### PR TITLE
test: fix missing Task using

### DIFF
--- a/tests/FitnessTracker.Tests/FitnessTracker.Tests.csproj
+++ b/tests/FitnessTracker.Tests/FitnessTracker.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+ <PropertyGroup>
+  <TargetFramework>net8.0</TargetFramework>
+  <IsPackable>false</IsPackable>
+  <Nullable>enable</Nullable>
+  <ImplicitUsings>enable</ImplicitUsings>
+</PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />

--- a/tests/FitnessTracker.Tests/HealthEndpointTests.cs
+++ b/tests/FitnessTracker.Tests/HealthEndpointTests.cs
@@ -2,6 +2,8 @@ using System.Net;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
+using System.Threading.Tasks;
+
 
 namespace FitnessTracker.Tests;
 


### PR DESCRIPTION
- Added using System.Threading.Tasks; to HealthEndpointTests.cs so async tests can compile.

- Enabled <ImplicitUsings>enable</ImplicitUsings> in FitnessTracker.Tests.csproj to avoid missing namespace errors in the future.

- Verified that tests build and run successfully with dotnet test.